### PR TITLE
missing discoverDevices() in the api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ class RNBluetoothClassic extends NativeEventEmitter {
 
     // Some/very untested functionality
     this.discoverUnpairedDevices = nativeModule.discoverUnpairedDevices;
+    this.discoverDevices = nativeModule.discoverDevices;
     this.cancelDiscovery = nativeModule.cancelDiscovery;
     this.pairDevice = nativeModule.pairDevice;
     this.unpairDevice = nativeModule.unpairDevice;


### PR DESCRIPTION
For some reason I don't see this method faced up on the Javascript API of the module. Doing this made it work for me.