### PR TITLE
Set Swift version to 4.1 to avoid compiling errors

### DIFF
--- a/react-native-bluetooth-classic.podspec
+++ b/react-native-bluetooth-classic.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
   s.homepage = "https://github.com/kenjdavidson/react-native-bluetooth-classic"
+  s.swift_version    = '4.1'
 
   s.dependency "React"
 end


### PR DESCRIPTION
I've got compiling errors after "pod install", so after setting swift version it works like a charm