### PR TITLE
Removing redundant delay

### DIFF
--- a/android/src/main/java/kjd/reactnative/bluetooth/RNBluetoothClassicService.java
+++ b/android/src/main/java/kjd/reactnative/bluetooth/RNBluetoothClassicService.java
@@ -469,7 +469,6 @@ public class RNBluetoothClassicService {
                     if (bytes > 0)
                         listener.onReceivedData(mmDevice, Arrays.copyOf(buffer, bytes));
 
-                    Thread.sleep(500);      // Pause
                 } catch (Exception e) {
                     Log.e(TAG, "Disconnected - was it cancelled? " + mmCancelled, e);
 


### PR DESCRIPTION
The code has a redundant delay added, but when sending data over bluetooth it simply slows down the received data capability. Removing it allows me to receive BT data with frequency of 1kHz without any artificially added delays.