### PR TITLE
Fix #123 & Expo Installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 .jest/
+*.tgz
   
 
 # Xcode

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ Windows isn't added yet - it looks like with the latest `react-native init` ther
   - Add `using Bluetooth.Classic.RNBluetoothClassic;` to the usings at the top of the file
   - Add `new RNBluetoothClassicPackage()` to the `List<IReactPackage>` returned by the `Packages` method
 
+### Expo Installation
+Install `react-native-bluetooth-classic` and `with-rn-bluetooth-classic` (for auto-configuration of permissions and protocols) from `npm` with `expo install`:
+```
+expo install react-native-bluetooth-classic with-rn-bluetooth-classic
+```
+Configure `app.json` or `app.config.json` with the following:
+```
+"plugins": [
+      ["with-bluetooth-classic",
+        {
+          "peripheralUsageDescription": "Allow myDevice to check bluetooth peripheral info",
+          "alwaysUsageDescription": "Allow myDevice to always use bluetooth info",
+          "protocols": [
+            "com.myCompany.p1",
+            "com.myCompany.p2"
+          ]
+        }
+      ]
+    ]
+```
 ## Contribute
 
 Feel free to contribute any changes or bug fixes you see fit.  Although when doing so please try to take into account that:

--- a/ios/RNBluetoothClassic.m
+++ b/ios/RNBluetoothClassic.m
@@ -94,8 +94,8 @@ RCT_EXTERN_METHOD(getConnectedDevice: (NSString *)deviceId
  * @param resolve
  * @param rejecter 
  */
-RCT_EXTERN_METHOD(getConnectedDevices: (RCTPromiseResolveBlock)resolve
-                  rejecter: (RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getConnectedDevices: (RCTPromiseResolveBlock)resolver
+                  rejecter: (RCTPromiseRejectBlock)reject)  
 
 /**
  * Attempt to write data to the device

--- a/ios/RNBluetoothClassic.swift
+++ b/ios/RNBluetoothClassic.swift
@@ -377,7 +377,7 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
      */
     @objc
     func getConnectedDevices(
-        resolver resolve: RCTPromiseResolveBlock,
+        _ resolve: RCTPromiseResolveBlock,
         rejecter reject: RCTPromiseRejectBlock
     ) -> Void {
         guard checkBluetoothAdapter() else {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf lib",
+    "clean-2": "rd /s /q lib",
     "tsc": "tsc",
+    "tsc-2": "npx tsc",
     "tsc:watch": "tsc --watch",
     "build": "npm run clean && npm run tsc",
+    "build-2": "npm run clean-2 && npm run tsc-2",
     "test": "jest",
     "preversion": "npm run build",
     "postversion": "git push && git push --tags && npm publish",

--- a/src/BluetoothDevice.ts
+++ b/src/BluetoothDevice.ts
@@ -114,7 +114,7 @@ export default class BluetoothDevice implements BluetoothNativeDevice {
    *
    * @return Promise resolving whether the clear was successful
    */
-  async clear(): Promise<number> {
+  async clear(): Promise<boolean> {
     return this._bluetoothModule.clearFromDevice(this.address);
   }
 


### PR DESCRIPTION
### Description
Update to README docs for Expo installation using `with-rn-bluetooth-classic` [config plugin](https://docs.expo.dev/guides/config-plugins/).
Fixes to iOS implementation of `getConnectedDevices` and `clear`. Solves issue #123.
### Testing Expo Plugin
Run `expo init expo-bluetooth-demo` to create a new managed workflow. Add the plugin with `expo install with-rn-bluetooth-classic`. For the External Accessory Framework, configure the `app.json` `plugin` array to include permission descriptions and protocol strings (as described in README addition). Run `expo config --type introspect` to view modified `plist` values and android permissions in the terminal. The result should include the new permissions and protocol strings under `modResults`
like [this](https://github.com/kenjdavidson/react-native-bluetooth-classic/files/7028115/introspect-results.txt).


