### PR TITLE
Fix base64 encoding

### DIFF
--- a/android/src/main/java/kjd/reactnative/bluetooth/conn/ByteArrayDeviceConnectionImpl.java
+++ b/android/src/main/java/kjd/reactnative/bluetooth/conn/ByteArrayDeviceConnectionImpl.java
@@ -83,7 +83,7 @@ public class ByteArrayDeviceConnectionImpl extends AbstractDeviceConnection {
      */
     @Override
     public String read() {
-        String message = Base64.encode(mBuffer.array(), Base64.DEFAULT).toString();
+        String message = Base64.encodeToString(mBuffer.array(), Base64.DEFAULT);
         clear();
 
         return message;


### PR DESCRIPTION
fixed issue returning byte[].toString() instead the Base64 encoded string