### PR TITLE
[iOS] Ask for bluetooth permission only when truly required

### DIFF
--- a/ios/RNBluetoothClassic.swift
+++ b/ios/RNBluetoothClassic.swift
@@ -40,7 +40,17 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
     var connectionFactories: Dictionary<String,DeviceConnectionFactory>
     
     private let eaManager: EAAccessoryManager
-    private let cbCentral: CBCentralManager
+
+    /**
+    *  By default, initialize CBCentralManager when bluetooth is not available prompts
+    *  "Turn On Bluetooth to Allow [app name] to Connect to Accessories" dialog.
+    *  See CBCentralManagerOptionShowPowerAlertKey for more details about this behavior
+    *
+    *  By using Lazy initialization on CBCentralManager it will prompt bluetooth permission
+    *  on first call of any bluetooth-related method.
+    */
+    private lazy var cbCentral: CBCentralManager = CBCentralManager()
+
     private let notificationCenter: NotificationCenter
     private let supportedProtocols: [String]
     
@@ -54,7 +64,6 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
      */
     override init() {
         self.eaManager = EAAccessoryManager.shared()
-        self.cbCentral = CBCentralManager()
         self.notificationCenter = NotificationCenter.default
         self.supportedProtocols = Bundle.main
             .object(forInfoDictionaryKey: "UISupportedExternalAccessoryProtocols") as! [String]


### PR DESCRIPTION
Hello, first of all, thank you for your amazing work

On iOS, using your library automatically prompt a "Turn On Bluetooth to Allow [app name] to Connect to Accessories" dialog **on app launch**.
![IMG_2828](https://user-images.githubusercontent.com/56835646/181264302-9e88bae7-5292-473f-bd04-d9e34da8537e.PNG)

For a better user experience, it is recommended to ask the user to enable bluetooth **when the application really need it**.

Found out that initialize CBCentralManager automatically prompt the bluetooth dialog by default. See [CBCentralManagerOptionShowPowerAlertKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionshowpoweralertkey?language=objc) 

To have the dialog prompt at right timing, CBManager can be initialized lazily, therefore, the permission dialog is prompt when needed instead of startup.
The first call of any bluetooth related method will trigger `checkBluetoothAdapter()` , initialize CBManager and prompt dialog.

They might be another way to achieve this result, (like setting `CBCentralManagerOptionShowPowerAlertKey` to `0` and ask to enable bluetooth later on) but I found that asking for enabling bluetooth on usage is the most natural way.