### PR TITLE
fix(ios): Remove throws in obj-c exposed swift methods

### DIFF
--- a/ios/RNBluetoothClassic.swift
+++ b/ios/RNBluetoothClassic.swift
@@ -569,7 +569,7 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
      }
      
     @objc
-    func removeListener(_ requestedEvent: String) throws {
+    func removeListener(_ requestedEvent: String) {
         var eventName = requestedEvent
         var eventDevice: String?
          
@@ -596,7 +596,7 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
     }
      
     @objc
-    func removeAllListeners(_ requestedEvent: String) throws {
+    func removeAllListeners(_ requestedEvent: String) {
         var eventName = requestedEvent
         var eventDevice: String?
         


### PR DESCRIPTION
Hi,
I wanted to use `removeListener` on iOS, but it throws an error:
```
Exception 'removeListener: is not a recognized Objective-C method.' was thrown while invoking removeListener on target RNBluetoothClassic with params ("DEVICE_READ@C129 04051")
```
Digging into this bridge problem, the root cause is that the Swift signature does not match with the obj-c export:
Objective-C:
`CT_EXTERN_METHOD(removeListener: (NSString *)requestedEvent)`
Swift:
```
@objc
    func removeListener(_ requestedEvent: String) throws {}
```

I learned [here](https://developer.apple.com/forums/thread/68228)  that 

> When Swift exports throws-function to Objective-C, it does two things:
> Add an extra parameter taking a nullable pointer to `NSError*`.
> Change the return type to Optional, if the return type is Void, it is changed to `BOOL`.

Since the two methods `removeListener` & `removeAllListeners` seem to never throws, this PR simply remove the `throws` keyword and fixed my problem

![rn-classic-bl-error](https://user-images.githubusercontent.com/56835646/182587563-a79a3f3e-565e-4450-9d6b-928868047825.jpeg)
 