### PR TITLE
fix(build): Use project global buildToolsVersion and compileSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def getExtOrDefault(name, fallback) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : fallback
+}
+
 android {
-    compileSdkVersion 29
-    buildToolsVersion "28.0.3"
+    compileSdkVersion getExtOrDefault('compileSdkVersion', 29)
+    buildToolsVersion getExtOrDefault('buildToolsVersion', "28.0.3")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion getExtOrDefault('minSdkVersion', 16)
+        targetSdkVersion getExtOrDefault('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Should fix #202 

Make gradle use versions defined by your project 
* `compileSdkVersion` 
* `buildToolsVersion`
* `minSdkVersion`
* `targetSdkVersion`


They are grabbed from your global `android/build.gradle` and should automatically evolve with react-native updates