### PR TITLE
deviceClass was initialized and filled but NOT added to mapped object

### DIFF
--- a/android/src/main/java/kjd/reactnative/bluetooth/device/NativeDevice.java
+++ b/android/src/main/java/kjd/reactnative/bluetooth/device/NativeDevice.java
@@ -71,6 +71,8 @@ public class NativeDevice implements Mappable {
             WritableMap deviceClass = Arguments.createMap();
             deviceClass.putInt("deviceClass", mDevice.getBluetoothClass().getDeviceClass());
             deviceClass.putInt("majorClass", mDevice.getBluetoothClass().getMajorDeviceClass());
+
+            mapped.putMap("deviceClass", deviceClass);
         }
 
         mapped.putMap("extra", Arguments.makeNativeMap(mExtra));


### PR DESCRIPTION
In the NativeDevice class in the map() method, deviceClass was initialized and filled but not added to mapped object