### PR TITLE
Fix unpairDevice calling cancelDiscovery

### DIFF
--- a/src/BluetoothModule.ts
+++ b/src/BluetoothModule.ts
@@ -278,7 +278,7 @@ export default class BluetoothModule {
    */
   unpairDevice(address: string): Promise<boolean> {
     if (Platform.OS == "ios") throw new Error("Method not implemented.");
-    return this._nativeModule.cancelDiscovery();
+    return this._nativeModule.unpairDevice(address);
   }
 
   /**


### PR DESCRIPTION
My proposal to fix https://github.com/kenjdavidson/react-native-bluetooth-classic/issues/252

It seems that `unpairDevice` should be calling `this._nativeModule.unpairDevice(address)` rather than `this._nativeModule.cancelDiscovery()`.