### PR TITLE
Remove condition when writing buffer data on IOS

### DIFF
--- a/ios/conn/DelimitedStringDeviceConnectionImpl.swift
+++ b/ios/conn/DelimitedStringDeviceConnectionImpl.swift
@@ -148,18 +148,14 @@ class DelimitedStringDeviceConnectionImpl : NSObject, DeviceConnection, StreamDe
      * - parameter message: the encoded message which will be written
      */
     func write(_ data: Data) -> Bool {
-        if let sending = String(data: data, encoding: self.encoding) {
-            NSLog("(BluetoothDevice:writeToDevice) Writing %@ to device %@", sending, accessory.serialNumber)
-            outBuffer.append(data)
+        NSLog("(BluetoothDevice:writeToDevice) Writing to device %@", accessory.serialNumber)
+        outBuffer.append(data)
 
-            // If there is space available for writing then we want to kick off the process.
-            // If all the data cannot be fully written, then the hasSpaceAvailable will be
-            // fired and we can continue.  In most cases, we shouldn't be sending that much
-            // data.
-            writeDataToStream((session?.outputStream)!)
-        } else {
-            return false
-        }
+        // If there is space available for writing then we want to kick off the process.
+        // If all the data cannot be fully written, then the hasSpaceAvailable will be
+        // fired and we can continue.  In most cases, we shouldn't be sending that much
+        // data.
+        writeDataToStream((session?.outputStream)!)
 
         return true
     }


### PR DESCRIPTION
I suggest removing the condition when writing buffer data on iOS: `if let sending = String(data: data, encoding: self.encoding)`.

When I tried to send buffer data, it couldn't go through the condition when the value was greater than 127. For example: Buffer.from([255]).

After removing the condition, the data could be processed and the printer worked exactly as it does on Android.