### PR TITLE
added android build/gradle namespace to support AGP >= 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,12 @@ def getExtOrDefault(name, fallback) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "kjd.reactnative.android"
+    }
+
     compileSdkVersion getExtOrDefault('compileSdkVersion', 34)
     buildToolsVersion getExtOrDefault('buildToolsVersion', "34.0.0")
 


### PR DESCRIPTION
Hi @kenjdavidson, I just raised a PR to add support for React Native that requires AGP >= 7? Thanks