### PR TITLE
Fix/agp support android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,13 @@ def getExtOrDefault(name, fallback) {
 }
 
 android {
+    // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
+    // it looks like this causes issues between 7 and 8, so for the time being 
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION    
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "kjd.reactnative.bluetooth"
+    }
+    
     compileSdkVersion getExtOrDefault('compileSdkVersion', 34)
     buildToolsVersion getExtOrDefault('buildToolsVersion', "34.0.0")
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="kjd.reactnative.bluetooth">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />


### PR DESCRIPTION
@mardikarifqi and @larlin can you take a look at this?

Looking at the link https://github.com/react-native-community/discussions-and-proposals/issues/671 this requires two changes:

1. Adding the `package` to the `build.gradle` file
2. Removing the `package` from the `AndroidManifest.xml` file

The latter was missed.  The PR also used `kjd.reactnative.android` instead of `kjd.reactnative.bluetooth` which is in the manifest.  Not sure if that really matters, but probably.   

Anyhow, the `kjd.reactnative.android` package should be removed, all it's used for is back porting the `BiConsumer` to Java 7, which it should be able to skip now, as I have to update the library to Java 17 based on this document and the 0.73 details anyhow.