### PR TITLE
fix: Bluetooth Event type

### DIFF
--- a/src/BluetoothEvent.ts
+++ b/src/BluetoothEvent.ts
@@ -38,9 +38,7 @@ export interface StateChangeEvent extends BluetoothEvent {
  * Device events used for connection/disconnection.  This looks like it's duplicating
  * the device and can probably be removed.
  */
-export interface BluetoothDeviceEvent extends BluetoothEvent {
-  device: BluetoothNativeDevice;
-}
+export interface BluetoothDeviceEvent extends BluetoothNativeDevice { }
 
 /**
  * Device read events.


### PR DESCRIPTION
it is just a copy of the device type

I thought this was the easiest fix, otherwise, a lot of changes are needed to make the existing type definition valid.

Fixes kenjdavidson/react-native-bluetooth-classic#332

