### PR TITLE
feat: add Bluetooth device type property on NativeDevice class

### DIFF
--- a/android/src/main/java/kjd/reactnative/bluetooth/device/NativeDevice.java
+++ b/android/src/main/java/kjd/reactnative/bluetooth/device/NativeDevice.java
@@ -58,6 +58,15 @@ public class NativeDevice implements Mappable {
         return (T) mExtra.put(key, value);
     }
 
+    private String getBlutoothTypeString() {
+        return switch (mDevice.getType()) {
+            case BluetoothDevice.DEVICE_TYPE_CLASSIC -> "CLASSIC";
+            case BluetoothDevice.DEVICE_TYPE_LE -> "LOW_ENERGY";
+            case BluetoothDevice.DEVICE_TYPE_DUAL -> "DUAL";
+            default -> "UNKNOWN";
+        };
+    }
+
     @Override
     public WritableMap map() {
         WritableMap mapped = Arguments.createMap();
@@ -66,6 +75,7 @@ public class NativeDevice implements Mappable {
         mapped.putString("address", mDevice.getAddress());
         mapped.putString("id", mDevice.getAddress());
         mapped.putBoolean("bonded", mDevice.getBondState() == BluetoothDevice.BOND_BONDED);
+        mapped.putString("type", this.getBlutoothTypeString());
 
         if (mDevice.getBluetoothClass() != null) {
             WritableMap deviceClass = Arguments.createMap();

--- a/ios/device/NativeDevice.swift
+++ b/ios/device/NativeDevice.swift
@@ -30,6 +30,7 @@ class NativeDevice: NSObject, Mappable {
             "bonded": accessory.isConnected,
             "deviceClass": accessory.modelNumber,
             "protocolStrings": accessory.protocolStrings,
+            "type": "CLASSIC",
             "extra": [:]
         ];
     }

--- a/src/BluetoothDevice.ts
+++ b/src/BluetoothDevice.ts
@@ -25,6 +25,7 @@ export default class BluetoothDevice implements BluetoothNativeDevice {
   bonded?: Boolean;
   deviceClass?: string;
   rssi: Number;
+  type: 'CLASSIC' | 'LOW_ENERGY' | 'DUAL' | 'UNKNOWN';
   extra: Map<string, Object>;
 
   constructor(nativeDevice: BluetoothNativeDevice, bluetoothModule: BluetoothModule) {
@@ -37,6 +38,7 @@ export default class BluetoothDevice implements BluetoothNativeDevice {
     this.bonded = nativeDevice.bonded;
     this.deviceClass = nativeDevice.deviceClass;
     this.rssi = nativeDevice.rssi;
+    this.type = nativeDevice.type;
     this.extra = nativeDevice.extra;
   }
 

--- a/src/BluetoothNativeDevice.ts
+++ b/src/BluetoothNativeDevice.ts
@@ -36,6 +36,11 @@ export default interface BluetoothNativeDevice {
   rssi: Number;
 
   /**
+   * Bluetooth device type of the remote device
+   */
+  type: 'CLASSIC' | 'LOW_ENERGY' | 'DUAL' | 'UNKNOWN'
+
+  /**
    * Extra information.  This could contain things like RSSI value
    * or other details.
    */


### PR DESCRIPTION
Hello!

### Proposal

Add the `type` property to the `NativeDevice` class to indicate the type of Bluetooth connection.

### Motivation

Some hybrid-capable Bluetooth controllers (Classic and Low Energy) emit two distinct MAC addresses during scanning—one for Bluetooth Classic and another for Bluetooth Low Energy. To simplify connecting exclusively to Bluetooth Classic, this property has been added to identify the connection type for each discovered MAC address.

This feature can be particularly useful on the JavaScript side, as it allows filtering and connecting only to MAC addresses associated specifically with Bluetooth Classic connections.

### Implementation

I mapped the `type` property within the `NativeDevice` class, where the `getType()` method from the `BluetoothDevice` class is used to determine the type of Bluetooth connection. The possible types are: CLASSIC, LE, DUAL, and UNKNOWN.

Reference: https://developer.android.com/reference/android/bluetooth/BluetoothDevice#getType()

Let me know if you have any questions!