### PR TITLE
fix: crash on init

### DIFF
--- a/ios/RNBluetoothClassic.swift
+++ b/ios/RNBluetoothClassic.swift
@@ -66,7 +66,7 @@ class RNBluetoothClassic : NSObject, RCTBridgeModule {
         self.eaManager = EAAccessoryManager.shared()
         self.notificationCenter = NotificationCenter.default
         self.supportedProtocols = Bundle.main
-            .object(forInfoDictionaryKey: "UISupportedExternalAccessoryProtocols") as! [String]
+            .object(forInfoDictionaryKey: "UISupportedExternalAccessoryProtocols") as? [String] ?? []
         
         self.connectionFactories = Dictionary()
         self.connectionFactories["delimited"] = DelimitedStringDeviceConnectionFactory()


### PR DESCRIPTION
## Summary 

For some reason in an app built with expo 51 and dev-client, This library was producing an insta crash with the following stacktrace

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Incident Identifier: 573E1755-BABC-4054-9D58-6A0877D56294
CrashReporter Key:   643738D2-7BBB-2270-5473-456E4C74105A
Hardware Model:      Mac14,7
Process:             7amBusiness [82367]
Path:                /Users/USER/Library/Developer/CoreSimulator/Devices/1807B878-0DA1-426A-B416-7C842204D06A/data/Containers/Bundle/Application/C297DDA7-783D-47ED-A0F6-DAFED5C8472D/7amBusiness.app/7amBusiness
Identifier:          io.sevenam.business
Version:             1.1.0 (1)
Code Type:           ARM-64 (Native)
Role:                Foreground
Parent Process:      launchd_sim [42591]
Coalition:           com.apple.CoreSimulator.SimDevice.1807B878-0DA1-426A-B416-7C842204D06A [137209]
Responsible Process: SimulatorTrampoline [1554]

Date/Time:           2025-02-28 12:21:58.9560 +0530
Launch Time:         2025-02-28 12:21:57.9804 +0530
OS Version:          macOS 15.3.1 (24D70)
Release Type:        User
Report Version:      104

Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Exception Codes: 0x0000000000000001, 0x00000001929f43a0
Termination Reason: SIGNAL 5 Trace/BPT trap: 5
Terminating Process: exc handler [82367]

Triggered by Thread:  0

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libswiftCore.dylib                       0x1929f43a0 closure #1 in closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) + 224
1   libswiftCore.dylib                       0x1929f427c closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) + 316
2   libswiftCore.dylib                       0x1929f3ce8 _assertionFailure(_:_:file:line:flags:) + 168
3   7amBusiness.debug.dylib                  0x106f373ec RNBluetoothClassic.init() + 632 (RNBluetoothClassic.swift:69)
4   7amBusiness.debug.dylib                  0x106f37670 @objc RNBluetoothClassic.init() + 20
5   7amBusiness.debug.dylib                  0x1065e5638 __115-[RCTModuleData initWithModuleClass:bridge:moduleRegistry:viewRegistry_DEPRECATED:bundleManager:callableJSModules:]_block_invoke + 36 (RCTModuleData.mm:92)
6   7amBusiness.debug.dylib                  0x1065e614c -[RCTModuleData setUpInstanceAndBridge:] + 1440 (RCTModuleData.mm:166)
7   7amBusiness.debug.dylib                  0x1065e82c4 __25-[RCTModuleData instance]_block_invoke + 44 (RCTModuleData.mm:377)
8   7amBusiness.debug.dylib                  0x10664a238 RCTUnsafeExecuteOnMainQueueSync + 52 (RCTUtils.m:289)
9   7amBusiness.debug.dylib                  0x1065e7f24 -[RCTModuleData instance] + 812 (RCTModuleData.mm:376)
10  7amBusiness.debug.dylib                  0x10658fd2c __49-[RCTCxxBridge _prepareModulesWithDispatchGroup:]_block_invoke + 160 (RCTCxxBridge.mm:1007)
11  libdispatch.dylib                        0x18016b4f4 _dispatch_call_block_and_release + 24
12  libdispatch.dylib                        0x18016cd3c _dispatch_client_callout + 16
13  libdispatch.dylib                        0x18017bb60 _dispatch_main_queue_drain + 1332
14  libdispatch.dylib                        0x18017b61c _dispatch_main_queue_callback_4CF + 40
15  CoreFoundation                           0x1803f1a30 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
16  CoreFoundation                           0x1803ec148 __CFRunLoopRun + 1936
17  CoreFoundation                           0x1803eb5a4 CFRunLoopRunSpecific + 572
18  GraphicsServices                         0x18e9fbae4 GSEventRunModal + 160
19  UIKitCore                                0x1852f02e4 -[UIApplication _run] + 868
20  UIKitCore                                0x1852f3f5c UIApplicationMain + 124
21  7amBusiness.debug.dylib                  0x105aea900 __debug_main_executable_dylib_entry_point + 96 (main.m:7)
22  dyld_sim                                 0x100bad544 start_sim + 20
23  dyld                                     0x100c6a274 start + 2840
```

This led me to look at `RNBluetoothClassic.swift` line 69
When I relaxed this lookup this app stopped crashing again.
For the time being I have patch-packaged this change, but would be good for this change to also exist upstream.

Do let me know what you think @kenjdavidson 

Thanks for this library and your time.
I appreciate it.
