### PR TITLE
 fix(android): add @Deprecated to solve obsolete warning.

### DIFF
--- a/android/src/main/java/kjd/reactnative/bluetooth/RNBluetoothClassicPackage.java
+++ b/android/src/main/java/kjd/reactnative/bluetooth/RNBluetoothClassicPackage.java
@@ -106,6 +106,7 @@ public class RNBluetoothClassicPackage implements ReactPackage {
     /**
      * @deprecated in version 0.47
      */
+    @Deprecated
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
<img width="2880" height="1840" alt="Snipaste_2025-09-26_20-12-03" src="https://github.com/user-attachments/assets/b4c6fdcb-1175-47c3-a067-23af0b8202db" />
